### PR TITLE
Use ascii-code

### DIFF
--- a/mozc.py
+++ b/mozc.py
@@ -271,6 +271,8 @@ class MozcShowSuggestCommand(sublime_plugin.TextCommand):
 class MozcSendKeyCommand(sublime_plugin.TextCommand):
     def run(self, edit, key):
         if mozc_mode and not mozc_qp_mode:
+            if len(key) == 1:
+                key = ord(key)
             oobj = communicate('SendKey', "{0} {1}".format(sess_count, key))["output"]
             print_debug("###",key,oobj)
             if 'result' in oobj:


### PR DESCRIPTION
セミコロンなどをtypeするとS式のシンタックスエラーが帰ってくるようです。

```
% mozc_emacs_helper
((mozc-emacs-helper . t)(version . "1.13.1651.102")(config . ((preedit-method . roman))))
(1 CreateSession)(4 SendKey 1 ;)
((error . scan-error)(message . "S expression in the wrong format"))
```

キーが一文字の場合はASCIIコードを使うように修正してみました。
手元ではうまく動いています。
